### PR TITLE
Create a backend endpoint to get a s3 pre-signed url and a cloudfront url for a video.

### DIFF
--- a/server/src/routes/courseRoutes.ts
+++ b/server/src/routes/courseRoutes.ts
@@ -6,6 +6,7 @@ import {
   createCourse,
   updateCourse,
   deleteCourse,
+  getUploadVideoUrl,
 } from "../controllers/courseController";
 import { requireAuth } from "@clerk/express";
 
@@ -18,5 +19,11 @@ router.post("/", requireAuth(), createCourse);
 router.get("/:courseId", getCourse);
 router.put("/:courseId", requireAuth(), upload.single("image"), updateCourse); // this is a multer middleware that will upload the image to the server
 router.delete("/:courseId", requireAuth(), deleteCourse);
+
+router.post(
+  "/:courseId/sections/:sectionId/chapters/:chapterId/get-upload-url",
+  requireAuth(),
+  getUploadVideoUrl
+);
 
 export default router;


### PR DESCRIPTION
### Summary
Adds a backend endpoint to generate:

An S3 pre-signed URL for uploading a video.

A CloudFront URL for serving the uploaded video via CDN.

### Motivation
Enables secure, time-limited video uploads to S3 and fast content delivery through CloudFront.

### Changes

Implemented backend route to request a pre-signed S3 URL.

Integrated logic to return the corresponding CloudFront URL.