### PR TITLE
Change the old ReactPlayer v2 API to the v3 API in the chapterId page.

### DIFF
--- a/client/src/app/(dashboard)/user/courses/[courseId]/chapters/[chapterId]/page.tsx
+++ b/client/src/app/(dashboard)/user/courses/[courseId]/chapters/[chapterId]/page.tsx
@@ -25,7 +25,29 @@ const Course = () => {
 
   const playerRef = useRef<ComponentRef<typeof ReactPlayer>>(null);
 
-  const handleProgress = ({ played }: { played: number }) => {
+  // const handleProgress = ({ played }: { played: number }) => {
+  //   if (
+  //     played >= 0.8 &&
+  //     !hasMarkedComplete &&
+  //     currentChapter &&
+  //     currentSection &&
+  //     userProgress?.sections &&
+  //     !isChapterCompleted()
+  //   ) {
+  //     setHasMarkedComplete(true);
+  //     updateChapterProgress(
+  //       currentSection.sectionId,
+  //       currentChapter.chapterId,
+  //       true
+  //     );
+  //   }
+  // };
+
+  const handleTimeUpdate: React.ReactEventHandler<HTMLVideoElement> = (e) => {
+    const el = e.currentTarget;
+    const duration = el.duration || 0;
+    const played = duration ? el.currentTime / duration : 0;
+
     if (
       played >= 0.8 &&
       !hasMarkedComplete &&
@@ -78,18 +100,21 @@ const Course = () => {
             {currentChapter?.video ? (
               <ReactPlayer
                 ref={playerRef}
-                url={currentChapter.video as string}
-                controls={true}
+                // url={currentChapter.video as string}
+                src={currentChapter.video as string}
+                controls
                 width="100%"
                 height="100%"
-                onProgress={handleProgress}
-                config={{
-                  file: {
-                    attributes: {
-                      controlsList: "nodownload",
-                    },
-                  },
-                }}
+                onTimeUpdate={handleTimeUpdate}
+                controlsList="nodownload"
+                // onProgress={handleProgress}
+                // config={{
+                //   file: {
+                //     attributes: {
+                //       controlsList: "nodownload",
+                //     },
+                //   },
+                // }}
               />
             ) : (
               <div className="course__no-video">


### PR DESCRIPTION
## Summary

This PR updates the `<Course />` component to align with **React Player v3** API changes and resolve TypeScript errors.

### Key Changes
- **Replaced** `url` prop with `src` (per v3 migration guide).
- **Removed** deprecated `config.file` usage; now pass `controlsList="nodownload"` directly to `<ReactPlayer />`.
- **Replaced** old `onProgress` callback (which provided `{ played }`) with a new `onTimeUpdate` handler that:
  - Uses the native HTMLVideoElement event.
  - Calculates the `played` percentage from `currentTime` and `duration`.
- **Updated** TypeScript typings to match v3 expectations (`ReactEventHandler<HTMLVideoElement>`).

### Motivation
React Player v3 changed the API:
- `onProgress` now receives a native event, not a `{ played }` object.
- The `config.file` property has been removed.
- `url` prop renamed to `src`.

This PR ensures our player logic is compatible with the new API and fixes the following TS errors:
- `TS2322`: Type mismatch for `onProgress` prop.
- `TS2353`: Unknown property `'file'` in `config`.

### References
- [React Player v3 Migration Guide](https://github.com/cookpete/react-player#v3-breaking-changes)