### PR TITLE
Set up AWS production environment at backend.

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -22,6 +22,7 @@
         "morgan": "^1.10.0",
         "multer": "^2.0.2",
         "pluralize": "^8.0.0",
+        "serverless-http": "^3.2.0",
         "stripe": "^18.3.0",
         "uuid": "^11.1.0"
       },
@@ -3840,6 +3841,15 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/serverless-http": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/serverless-http/-/serverless-http-3.2.0.tgz",
+      "integrity": "sha512-QvSyZXljRLIGqwcJ4xsKJXwkZnAVkse1OajepxfjkBXV0BMvRS5R546Z4kCBI8IygDzkQY0foNPC/rnipaE9pQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/set-function-length": {

--- a/server/package.json
+++ b/server/package.json
@@ -26,6 +26,7 @@
     "morgan": "^1.10.0",
     "multer": "^2.0.2",
     "pluralize": "^8.0.0",
+    "serverless-http": "^3.2.0",
     "stripe": "^18.3.0",
     "uuid": "^11.1.0"
   },


### PR DESCRIPTION
Wrap Express app with serverless(app) to make it Lambda-compatible.

Add special “seed” action in the exported handler:
- If event.action === "seed", run seed() and return 200 response.
- Otherwise, pass request to the serverless-wrapped app.

Note: Seeding via this handler is quick for cloud setup, but unsafe if left open. Restrict access with a custom authorizer, environment check, or remove after initial deploy to prevent unwanted DB reseeding.